### PR TITLE
fix: fix concurrency problems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1"
 rand = "0.8.5"
-dashmap = { git = "https://github.com/xacrimon/dashmap.git", branch = "master", features = ["inline"] }
+dashmap = { version = "5.5.0", features = ["inline"] }
 derive_builder = "0.12.0"
 deadpool = { version = "0.9.5", default-features = false, features = ["managed"] }
 chrono = "0.4.26"
-burn = { git = "https://github.com/burn-rs/burn.git", branch = "main" }
+burn = "0.9.0"
 serde = { version = "1.0.163", features = ["derive"] }
+typed-builder = "0.16.2"

--- a/cml-core/Cargo.toml
+++ b/cml-core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = { workspace = true }
 dashmap = { workspace = true }
 derive-getters = "0.2.1"
-derive_builder = { workspace = true }
+typed-builder = { workspace = true }
 deadpool = { workspace = true }
 serde = { workspace = true }
 chrono = { workspace = true }

--- a/cml-core/src/core/inference.rs
+++ b/cml-core/src/core/inference.rs
@@ -1,17 +1,18 @@
-use crate::metadata::MetaData;
+use crate::{metadata::Metadata, SharedBatchState};
 use anyhow::Result;
 use deadpool::managed::{Manager, Pool};
 use derive_getters::Getters;
 use std::path::PathBuf;
+use typed_builder::TypedBuilder;
 
-#[derive(Builder, Getters)]
+#[derive(TypedBuilder, Getters)]
 pub struct NewSample<F> {
     data_path: PathBuf,
-    #[builder(default = "None")]
+    #[builder(default, setter(strip_option))]
     output: Option<F>,
-    #[builder(default = "None")]
+    #[builder(default, setter(strip_option))]
     optional_fields: Option<Vec<F>>,
-    #[builder(default = "None")]
+    #[builder(default, setter(strip_option))]
     optional_tags: Option<Vec<F>>,
 }
 
@@ -25,9 +26,10 @@ pub trait Inference<M, F, T, C: Manager> {
 
     async fn inference<FN>(
         &self,
-        metadata: MetaData<F>,
+        metadata: Metadata<F>,
         available_status: &[&str],
         data: &mut Vec<NewSample<F>>,
+        batch_state: &SharedBatchState,
         pool: &Pool<C>,
         inference_fn: FN,
     ) -> Result<()>

--- a/cml-core/src/core/register.rs
+++ b/cml-core/src/core/register.rs
@@ -1,33 +1,16 @@
-use crate::metadata::MetaData;
+use crate::{metadata::Metadata, SharedBatchState};
 use anyhow::Result;
-use dashmap::DashMap;
 use deadpool::managed::{Manager, Pool};
 use derive_getters::Getters;
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::path::PathBuf;
+use typed_builder::TypedBuilder;
 
-#[derive(Builder, Getters)]
+#[derive(TypedBuilder, Getters)]
 pub struct TrainData<F> {
     data_path: PathBuf,
     gt: F,
-    #[builder(default = "None")]
+    #[builder(default, setter(strip_option))]
     optional_fields: Option<Vec<F>>,
-}
-
-pub struct BatchState {
-    pub map: DashMap<String, bool>,
-}
-
-pub type SharedBatchState = Arc<Mutex<BatchState>>;
-
-impl BatchState {
-    pub fn create(num_shards: usize) -> SharedBatchState {
-        Arc::new(Mutex::new(BatchState {
-            map: DashMap::with_shard_amount(num_shards),
-        }))
-    }
 }
 
 pub trait Register<M, F, C: Manager> {
@@ -40,9 +23,9 @@ pub trait Register<M, F, C: Manager> {
 
     async fn register(
         &self,
-        metadata: MetaData<F>,
+        metadata: &Metadata<F>,
         train_data: Vec<TrainData<F>>,
-        batch_state: Arc<Mutex<BatchState>>,
+        batch_state: &SharedBatchState,
         pool: &Pool<C>,
     ) -> Result<()>;
 }

--- a/cml-core/src/core/task.rs
+++ b/cml-core/src/core/task.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use chrono::Duration;
 use derive_getters::Getters;
+use typed_builder::TypedBuilder;
 
-#[derive(Builder, Getters, Clone)]
+#[derive(TypedBuilder, Getters, Clone)]
 pub struct TaskConfig<'a> {
     min_start_count: usize,
     min_update_count: usize,

--- a/cml-core/src/lib.rs
+++ b/cml-core/src/lib.rs
@@ -1,9 +1,13 @@
 #![allow(incomplete_features)]
 #![feature(async_fn_in_trait)]
 
-#[macro_use]
-extern crate derive_builder;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Condvar, Mutex},
+};
 
 pub mod core;
 pub mod handler;
 pub mod metadata;
+
+pub type SharedBatchState = Arc<(Mutex<HashSet<String>>, Condvar)>;

--- a/cml-core/src/metadata.rs
+++ b/cml-core/src/metadata.rs
@@ -1,17 +1,18 @@
 use derive_getters::Getters;
+use typed_builder::TypedBuilder;
 
-#[derive(Builder, Getters)]
-pub struct MetaData<F> {
+#[derive(TypedBuilder, Getters, Clone)]
+pub struct Metadata<F> {
     model_update_time: i64,
-    batch: String,
+    pub batch: String,
     inherent_field_num: usize,
     inherent_tag_num: usize,
     optional_field_num: usize,
-    #[builder(default = "None")]
+    #[builder(default, setter(strip_option))]
     optional_tags: Option<Vec<F>>,
 }
 
-impl<F> MetaData<F> {
+impl<F> Metadata<F> {
     pub fn get_placeholders(&self) -> (String, String) {
         (
             vec!["?"; self.optional_tags.as_ref().map_or(0, |v| v.len()) + self.inherent_tag_num]

--- a/cml-tdengine/Cargo.toml
+++ b/cml-tdengine/Cargo.toml
@@ -14,7 +14,7 @@ taos-query = { version = "*" }
 anyhow = { workspace = true }
 rand = { workspace = true }
 dashmap = { workspace = true }
-derive_builder = { workspace = true }
+typed-builder = { workspace = true }
 deadpool = { workspace = true }
 serde = { workspace = true }
 chrono = { workspace = true }
@@ -23,5 +23,5 @@ tokio = { version = "1.29.1", features = ["rt", "macros"] }
 
 [dev-dependencies]
 burn = { workspace = true }
-burn-autodiff = { git = "https://github.com/burn-rs/burn.git", branch = "main" }
-burn-ndarray = { git = "https://github.com/burn-rs/burn.git", branch = "main" }
+burn-autodiff = "0.9.0"
+burn-ndarray = "0.9.0"

--- a/cml-tdengine/src/core/task.rs
+++ b/cml-tdengine/src/core/task.rs
@@ -150,334 +150,334 @@ impl<D: IntoDsn + Clone> Task<Field> for TDengine<D> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::models::databases::{
-        options::{CacheModel, ReplicaNum, SingleSTable},
-        DatabaseBuilder,
-    };
-    use chrono::Duration;
-    use cml_core::core::task::TaskConfigBuilder;
-    use std::{fs::File, io::prelude::*};
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::models::databases::{
+//         options::{CacheModel, ReplicaNum, SingleSTable},
+//         DatabaseBuilder,
+//     };
+//     use chrono::Duration;
+//     use cml_core::core::task::TaskConfigBuilder;
+//     use std::{fs::File, io::prelude::*};
 
-    use burn::{
-        data::{
-            dataloader::{batcher::Batcher, DataLoaderBuilder},
-            dataset::Dataset,
-        },
-        module::Module,
-        nn::{
-            self,
-            loss::{MSELoss, Reduction},
-        },
-        optim::{decay::WeightDecayConfig, AdamConfig},
-        record::{CompactRecorder, NoStdTrainingRecorder, Recorder},
-        tensor::{
-            backend::{ADBackend, Backend},
-            Data, Tensor,
-        },
-        train::{LearnerBuilder, RegressionOutput, TrainOutput, TrainStep, ValidStep},
-    };
-    use burn_autodiff::ADBackendDecorator;
-    use burn_ndarray::{NdArrayBackend, NdArrayDevice};
+//     use burn::{
+//         data::{
+//             dataloader::{batcher::Batcher, DataLoaderBuilder},
+//             dataset::Dataset,
+//         },
+//         module::Module,
+//         nn::{
+//             self,
+//             loss::{MSELoss, Reduction},
+//         },
+//         optim::{decay::WeightDecayConfig, AdamConfig},
+//         record::{CompactRecorder, NoStdTrainingRecorder, Recorder},
+//         tensor::{
+//             backend::{ADBackend, Backend},
+//             Data, Tensor,
+//         },
+//         train::{LearnerBuilder, RegressionOutput, TrainOutput, TrainStep, ValidStep},
+//     };
+//     use burn_autodiff::ADBackendDecorator;
+//     use burn_ndarray::{NdArrayBackend, NdArrayDevice};
 
-    #[tokio::test]
-    async fn test_task_init() -> Result<()> {
-        let cml = TDengine::from_dsn("taos://");
-        let taos = cml.build().await?;
+//     #[tokio::test]
+//     async fn test_task_init() -> Result<()> {
+//         let cml = TDengine::from_dsn("taos://");
+//         let taos = cml.build().await?;
 
-        taos::AsyncQueryable::exec(&taos, "DROP DATABASE IF EXISTS task").await?;
+//         taos::AsyncQueryable::exec(&taos, "DROP DATABASE IF EXISTS task").await?;
 
-        let db = DatabaseBuilder::default()
-            .name("task")
-            .duration(30)
-            .keep(365)
-            .replica(ReplicaNum::NoReplica)
-            .cache_model(CacheModel::None)
-            .single_stable(SingleSTable::True)
-            .build()?;
-        db.init(&cml.build().await?, None).await?;
+//         let db = DatabaseBuilder::default()
+//             .name("task")
+//             .duration(30)
+//             .keep(365)
+//             .replica(ReplicaNum::NoReplica)
+//             .cache_model(CacheModel::None)
+//             .single_stable(SingleSTable::True)
+//             .build()?;
+//         db.init(&cml.build().await?, None).await?;
 
-        cml.init_task(None, None).await?;
+//         cml.init_task(None, None).await?;
 
-        assert_eq!(
-            taos_query::AsyncFetchable::to_records(
-                &mut taos::AsyncQueryable::query(&taos, "SHOW task.STABLES").await?
-            )
-            .await?[0][0],
-            taos::Value::VarChar("task".to_owned())
-        );
+//         assert_eq!(
+//             taos_query::AsyncFetchable::to_records(
+//                 &mut taos::AsyncQueryable::query(&taos, "SHOW task.STABLES").await?
+//             )
+//             .await?[0][0],
+//             taos::Value::VarChar("task".to_owned())
+//         );
 
-        taos::AsyncQueryable::exec(&taos, "DROP DATABASE IF EXISTS task").await?;
-        Ok(())
-    }
+//         taos::AsyncQueryable::exec(&taos, "DROP DATABASE IF EXISTS task").await?;
+//         Ok(())
+//     }
 
-    #[test]
-    fn test_task_running_in_parallel() -> Result<()> {
-        let cml = TDengine::from_dsn("taos://");
+//     #[test]
+//     fn test_task_running_in_parallel() -> Result<()> {
+//         let cml = TDengine::from_dsn("taos://");
 
-        let config: TaskConfig = TaskConfigBuilder::default()
-            .min_start_count(1)
-            .min_update_count(1)
-            .working_status(vec!["TRAIN", "EVAL"])
-            .limit_time(Duration::days(2))
-            .build()?;
+//         let config: TaskConfig = TaskConfigBuilder::default()
+//             .min_start_count(1)
+//             .min_update_count(1)
+//             .working_status(vec!["TRAIN", "EVAL"])
+//             .limit_time(Duration::days(2))
+//             .build()?;
 
-        for i in 1..=2 {
-            let mut file =
-                File::create(format!("/tmp/file_{}.txt", i)).expect("Unable to create file");
-            write!(file, "8.8").expect("Failed to write to file");
-        }
+//         for i in 1..=2 {
+//             let mut file =
+//                 File::create(format!("/tmp/file_{}.txt", i)).expect("Unable to create file");
+//             write!(file, "8.8").expect("Failed to write to file");
+//         }
 
-        let taos = cml.build_sync()?;
-        taos.exec("DROP DATABASE IF EXISTS training_data")?;
-        taos.exec("DROP DATABASE IF EXISTS task")?;
+//         let taos = cml.build_sync()?;
+//         taos.exec("DROP DATABASE IF EXISTS training_data")?;
+//         taos.exec("DROP DATABASE IF EXISTS task")?;
 
-        taos.exec("CREATE DATABASE IF NOT EXISTS training_data PRECISION 'ns'")?;
-        taos.exec("CREATE DATABASE IF NOT EXISTS task PRECISION 'ns'")?;
+//         taos.exec("CREATE DATABASE IF NOT EXISTS training_data PRECISION 'ns'")?;
+//         taos.exec("CREATE DATABASE IF NOT EXISTS task PRECISION 'ns'")?;
 
-        taos.exec(
-            "CREATE STABLE IF NOT EXISTS training_data.training_data
-            (ts TIMESTAMP, is_train BOOL, data_path NCHAR(255), gt FLOAT)
-            TAGS (model_update_time TIMESTAMP)",
-        )?;
-        taos.exec(
-            "CREATE STABLE IF NOT EXISTS task.task
-            (ts TIMESTAMP, status BINARY(8))
-            TAGS (model_update_time TIMESTAMP)",
-        )?;
+//         taos.exec(
+//             "CREATE STABLE IF NOT EXISTS training_data.training_data
+//             (ts TIMESTAMP, is_train BOOL, data_path NCHAR(255), gt FLOAT)
+//             TAGS (model_update_time TIMESTAMP)",
+//         )?;
+//         taos.exec(
+//             "CREATE STABLE IF NOT EXISTS task.task
+//             (ts TIMESTAMP, status BINARY(8))
+//             TAGS (model_update_time TIMESTAMP)",
+//         )?;
 
-        taos.exec(
-            "INSERT INTO training_data.`FUCK`
-            USING training_data.training_data
-            TAGS ('2022-08-08 18:18:18.518')
-            VALUES (NOW, 'true', '/tmp/file_1.txt', 1.0),
-            (NOW + 1s, 'false', '/tmp/file_2.txt', 2.0)",
-        )?;
-        taos.exec(
-            "INSERT INTO task.`FUCK`
-            USING task.task
-            TAGS ('2022-08-08 18:18:18.518')
-            VALUES (NOW -3d, 'TRAIN')",
-        )?;
+//         taos.exec(
+//             "INSERT INTO training_data.`FUCK`
+//             USING training_data.training_data
+//             TAGS ('2022-08-08 18:18:18.518')
+//             VALUES (NOW, 'true', '/tmp/file_1.txt', 1.0),
+//             (NOW + 1s, 'false', '/tmp/file_2.txt', 2.0)",
+//         )?;
+//         taos.exec(
+//             "INSERT INTO task.`FUCK`
+//             USING task.task
+//             TAGS ('2022-08-08 18:18:18.518')
+//             VALUES (NOW -3d, 'TRAIN')",
+//         )?;
 
-        taos.exec(
-            "INSERT INTO training_data.`FUCK8`
-            USING training_data.training_data
-            TAGS (null)
-            VALUES (NOW, 'true', '/tmp/file_1.txt', 1.0),
-            (NOW + 1s, 'false', '/tmp/file_2.txt', 2.0)",
-        )?;
-        taos.exec(
-            "INSERT INTO task.`FUCK8`
-            USING task.task
-            TAGS (null)
-            VALUES (NOW -3d, 'TRAIN')",
-        )?;
+//         taos.exec(
+//             "INSERT INTO training_data.`FUCK8`
+//             USING training_data.training_data
+//             TAGS (null)
+//             VALUES (NOW, 'true', '/tmp/file_1.txt', 1.0),
+//             (NOW + 1s, 'false', '/tmp/file_2.txt', 2.0)",
+//         )?;
+//         taos.exec(
+//             "INSERT INTO task.`FUCK8`
+//             USING task.task
+//             TAGS (null)
+//             VALUES (NOW -3d, 'TRAIN')",
+//         )?;
 
-        let build_fn = |b: &str| -> Result<()> {
-            type B = ADBackendDecorator<NdArrayBackend<f32>>;
-            B::seed(220225);
+//         let build_fn = |b: &str| -> Result<()> {
+//             type B = ADBackendDecorator<NdArrayBackend<f32>>;
+//             B::seed(220225);
 
-            pub struct DemoBatcher<B: Backend> {
-                device: B::Device,
-            }
+//             pub struct DemoBatcher<B: Backend> {
+//                 device: B::Device,
+//             }
 
-            #[derive(Clone, Debug)]
-            pub struct DemoBatch<B: Backend> {
-                pub features: Tensor<B, 2>,
-                pub targets: Tensor<B, 2>,
-            }
+//             #[derive(Clone, Debug)]
+//             pub struct DemoBatch<B: Backend> {
+//                 pub features: Tensor<B, 2>,
+//                 pub targets: Tensor<B, 2>,
+//             }
 
-            #[derive(Clone, Debug)]
-            pub struct DemoItem {
-                pub x: [f32; 1],
-                pub y: f32,
-            }
+//             #[derive(Clone, Debug)]
+//             pub struct DemoItem {
+//                 pub x: [f32; 1],
+//                 pub y: f32,
+//             }
 
-            impl<B: Backend> DemoBatcher<B> {
-                pub fn new(device: B::Device) -> Self {
-                    Self { device }
-                }
-            }
+//             impl<B: Backend> DemoBatcher<B> {
+//                 pub fn new(device: B::Device) -> Self {
+//                     Self { device }
+//                 }
+//             }
 
-            struct DemoDataset {
-                dataset: Vec<DemoItem>,
-            }
+//             struct DemoDataset {
+//                 dataset: Vec<DemoItem>,
+//             }
 
-            impl Dataset<DemoItem> for DemoDataset {
-                fn get(&self, index: usize) -> Option<DemoItem> {
-                    self.dataset.get(index).cloned()
-                }
-                fn len(&self) -> usize {
-                    self.dataset.len()
-                }
-            }
+//             impl Dataset<DemoItem> for DemoDataset {
+//                 fn get(&self, index: usize) -> Option<DemoItem> {
+//                     self.dataset.get(index).cloned()
+//                 }
+//                 fn len(&self) -> usize {
+//                     self.dataset.len()
+//                 }
+//             }
 
-            impl DemoDataset {
-                fn train(taos: &Taos, batch: &str) -> Self {
-                    Self::new(taos, batch, "true").unwrap()
-                }
+//             impl DemoDataset {
+//                 fn train(taos: &Taos, batch: &str) -> Self {
+//                     Self::new(taos, batch, "true").unwrap()
+//                 }
 
-                fn test(taos: &Taos, batch: &str) -> Self {
-                    Self::new(taos, batch, "false").unwrap()
-                }
+//                 fn test(taos: &Taos, batch: &str) -> Self {
+//                     Self::new(taos, batch, "false").unwrap()
+//                 }
 
-                fn new(taos: &Taos, batch: &str, is_train: &str) -> Result<Self> {
-                    let records = taos
-                        .query(format!(
-                            "SELECT data_path, gt FROM training_data.`{}` WHERE is_train = '{}'",
-                            batch, is_train
-                        ))?
-                        .to_rows_vec()?;
+//                 fn new(taos: &Taos, batch: &str, is_train: &str) -> Result<Self> {
+//                     let records = taos
+//                         .query(format!(
+//                             "SELECT data_path, gt FROM training_data.`{}` WHERE is_train = '{}'",
+//                             batch, is_train
+//                         ))?
+//                         .to_rows_vec()?;
 
-                    let mut dataset = Vec::<DemoItem>::new();
-                    for record in records {
-                        if let [Value::NChar(data_path), Value::Float(gt)] = record.as_slice() {
-                            let mut file = File::open(data_path).expect("Failed to open file");
-                            let mut contents = String::new();
-                            file.read_to_string(&mut contents)
-                                .expect("Failed to read from file");
+//                     let mut dataset = Vec::<DemoItem>::new();
+//                     for record in records {
+//                         if let [Value::NChar(data_path), Value::Float(gt)] = record.as_slice() {
+//                             let mut file = File::open(data_path).expect("Failed to open file");
+//                             let mut contents = String::new();
+//                             file.read_to_string(&mut contents)
+//                                 .expect("Failed to read from file");
 
-                            dataset.push(DemoItem {
-                                x: [contents.trim().parse().expect("Failed to parse number")],
-                                y: *gt,
-                            })
-                        }
-                    }
+//                             dataset.push(DemoItem {
+//                                 x: [contents.trim().parse().expect("Failed to parse number")],
+//                                 y: *gt,
+//                             })
+//                         }
+//                     }
 
-                    Ok(Self { dataset })
-                }
-            }
+//                     Ok(Self { dataset })
+//                 }
+//             }
 
-            impl<B: Backend> Batcher<DemoItem, DemoBatch<B>> for DemoBatcher<B> {
-                fn batch(&self, items: Vec<DemoItem>) -> DemoBatch<B> {
-                    let features = items
-                        .iter()
-                        .map(|item| Data::<f32, 1>::from(item.x))
-                        .map(|data| Tensor::<B, 1>::from_data(data.convert()))
-                        .map(|tensor| tensor.reshape([1, 1]))
-                        .collect();
+//             impl<B: Backend> Batcher<DemoItem, DemoBatch<B>> for DemoBatcher<B> {
+//                 fn batch(&self, items: Vec<DemoItem>) -> DemoBatch<B> {
+//                     let features = items
+//                         .iter()
+//                         .map(|item| Data::<f32, 1>::from(item.x))
+//                         .map(|data| Tensor::<B, 1>::from_data(data.convert()))
+//                         .map(|tensor| tensor.reshape([1, 1]))
+//                         .collect();
 
-                    let targets = items
-                        .iter()
-                        .map(|item| Data::<f32, 1>::from([item.y]))
-                        .map(|data| Tensor::<B, 1>::from_data(data.convert()))
-                        .map(|tensor| tensor.reshape([1, 1]))
-                        .collect();
+//                     let targets = items
+//                         .iter()
+//                         .map(|item| Data::<f32, 1>::from([item.y]))
+//                         .map(|data| Tensor::<B, 1>::from_data(data.convert()))
+//                         .map(|tensor| tensor.reshape([1, 1]))
+//                         .collect();
 
-                    let features = Tensor::cat(features, 0).to_device(&self.device);
-                    let targets = Tensor::cat(targets, 0).to_device(&self.device);
+//                     let features = Tensor::cat(features, 0).to_device(&self.device);
+//                     let targets = Tensor::cat(targets, 0).to_device(&self.device);
 
-                    DemoBatch { features, targets }
-                }
-            }
+//                     DemoBatch { features, targets }
+//                 }
+//             }
 
-            let device = NdArrayDevice::Cpu;
+//             let device = NdArrayDevice::Cpu;
 
-            #[derive(Module, Debug)]
-            pub struct Model<B: Backend> {
-                fc1: nn::Linear<B>,
-                fc2: nn::Linear<B>,
-                activation: nn::GELU,
-            }
+//             #[derive(Module, Debug)]
+//             pub struct Model<B: Backend> {
+//                 fc1: nn::Linear<B>,
+//                 fc2: nn::Linear<B>,
+//                 activation: nn::GELU,
+//             }
 
-            impl<B: Backend> Model<B> {
-                pub fn new() -> Self {
-                    let fc1 = nn::LinearConfig::new(1, 4).with_bias(false).init();
-                    let fc2 = nn::LinearConfig::new(4, 1).with_bias(false).init();
+//             impl<B: Backend> Model<B> {
+//                 pub fn new() -> Self {
+//                     let fc1 = nn::LinearConfig::new(1, 4).with_bias(false).init();
+//                     let fc2 = nn::LinearConfig::new(4, 1).with_bias(false).init();
 
-                    Self {
-                        fc1,
-                        fc2,
-                        activation: nn::GELU::new(),
-                    }
-                }
+//                     Self {
+//                         fc1,
+//                         fc2,
+//                         activation: nn::GELU::new(),
+//                     }
+//                 }
 
-                pub fn forward(&self, input: Tensor<B, 2>) -> Tensor<B, 2> {
-                    let [batch_size, feature_num] = input.dims();
+//                 pub fn forward(&self, input: Tensor<B, 2>) -> Tensor<B, 2> {
+//                     let [batch_size, feature_num] = input.dims();
 
-                    let x = input.reshape([batch_size, feature_num]).detach();
+//                     let x = input.reshape([batch_size, feature_num]).detach();
 
-                    let [batch_size, feature_num] = x.dims();
-                    let x = x.reshape([batch_size, feature_num]);
+//                     let [batch_size, feature_num] = x.dims();
+//                     let x = x.reshape([batch_size, feature_num]);
 
-                    let x = self.fc1.forward(x);
-                    let x = self.activation.forward(x);
+//                     let x = self.fc1.forward(x);
+//                     let x = self.activation.forward(x);
 
-                    self.fc2.forward(x)
-                }
+//                     self.fc2.forward(x)
+//                 }
 
-                pub fn forward_regression(&self, item: DemoBatch<B>) -> RegressionOutput<B> {
-                    let targets = item.targets;
-                    let output = self.forward(item.features);
-                    let loss = MSELoss::new();
-                    let loss = loss.forward(output.clone(), targets.clone(), Reduction::Auto);
+//                 pub fn forward_regression(&self, item: DemoBatch<B>) -> RegressionOutput<B> {
+//                     let targets = item.targets;
+//                     let output = self.forward(item.features);
+//                     let loss = MSELoss::new();
+//                     let loss = loss.forward(output.clone(), targets.clone(), Reduction::Auto);
 
-                    RegressionOutput {
-                        loss,
-                        output,
-                        targets,
-                    }
-                }
-            }
+//                     RegressionOutput {
+//                         loss,
+//                         output,
+//                         targets,
+//                     }
+//                 }
+//             }
 
-            impl<B: ADBackend> TrainStep<DemoBatch<B>, RegressionOutput<B>> for Model<B> {
-                fn step(&self, item: DemoBatch<B>) -> TrainOutput<RegressionOutput<B>> {
-                    let item = self.forward_regression(item);
+//             impl<B: ADBackend> TrainStep<DemoBatch<B>, RegressionOutput<B>> for Model<B> {
+//                 fn step(&self, item: DemoBatch<B>) -> TrainOutput<RegressionOutput<B>> {
+//                     let item = self.forward_regression(item);
 
-                    TrainOutput::new(self, item.loss.backward(), item)
-                }
-            }
+//                     TrainOutput::new(self, item.loss.backward(), item)
+//                 }
+//             }
 
-            impl<B: Backend> ValidStep<DemoBatch<B>, RegressionOutput<B>> for Model<B> {
-                fn step(&self, item: DemoBatch<B>) -> RegressionOutput<B> {
-                    self.forward_regression(item)
-                }
-            }
+//             impl<B: Backend> ValidStep<DemoBatch<B>, RegressionOutput<B>> for Model<B> {
+//                 fn step(&self, item: DemoBatch<B>) -> RegressionOutput<B> {
+//                     self.forward_regression(item)
+//                 }
+//             }
 
-            let batcher_train = DemoBatcher::<B>::new(device);
-            let batcher_valid = DemoBatcher::<<burn_autodiff::ADBackendDecorator<burn_ndarray::NdArrayBackend<f32>> as burn::tensor::backend::ADBackend>::InnerBackend>::new(device);
+//             let batcher_train = DemoBatcher::<B>::new(device);
+//             let batcher_valid = DemoBatcher::<<burn_autodiff::ADBackendDecorator<burn_ndarray::NdArrayBackend<f32>> as burn::tensor::backend::ADBackend>::InnerBackend>::new(device);
 
-            let dataloader_train = DataLoaderBuilder::new(batcher_train)
-                .batch_size(1)
-                .shuffle(220225)
-                .num_workers(1)
-                .build(DemoDataset::train(&taos, b));
-            let dataloader_test = DataLoaderBuilder::new(batcher_valid)
-                .batch_size(1)
-                .shuffle(220225)
-                .num_workers(1)
-                .build(DemoDataset::test(&taos, b));
+//             let dataloader_train = DataLoaderBuilder::new(batcher_train)
+//                 .batch_size(1)
+//                 .shuffle(220225)
+//                 .num_workers(1)
+//                 .build(DemoDataset::train(&taos, b));
+//             let dataloader_test = DataLoaderBuilder::new(batcher_valid)
+//                 .batch_size(1)
+//                 .shuffle(220225)
+//                 .num_workers(1)
+//                 .build(DemoDataset::test(&taos, b));
 
-            let config_optimizer =
-                AdamConfig::new().with_weight_decay(Some(WeightDecayConfig::new(5e-5)));
+//             let config_optimizer =
+//                 AdamConfig::new().with_weight_decay(Some(WeightDecayConfig::new(5e-5)));
 
-            let working_dir = "/tmp/work_dir";
-            let learner = LearnerBuilder::new(working_dir)
-                .with_file_checkpointer(1, CompactRecorder::new())
-                .devices(vec![device])
-                .num_epochs(1)
-                .build(Model::<B>::new(), config_optimizer.init(), 1e-4);
+//             let working_dir = "/tmp/work_dir";
+//             let learner = LearnerBuilder::new(working_dir)
+//                 .with_file_checkpointer(1, CompactRecorder::new())
+//                 .devices(vec![device])
+//                 .num_epochs(1)
+//                 .build(Model::<B>::new(), config_optimizer.init(), 1e-4);
 
-            let model_trained = learner.fit(dataloader_train, dataloader_test);
+//             let model_trained = learner.fit(dataloader_train, dataloader_test);
 
-            NoStdTrainingRecorder::new()
-                .record(
-                    model_trained.into_record(),
-                    format!("{working_dir}/model").into(),
-                )
-                .expect("Failed to save trained model");
+//             NoStdTrainingRecorder::new()
+//                 .record(
+//                     model_trained.into_record(),
+//                     format!("{working_dir}/model").into(),
+//                 )
+//                 .expect("Failed to save trained model");
 
-            Ok(())
-        };
+//             Ok(())
+//         };
 
-        cml.run(config, build_fn, build_fn)?;
+//         cml.run(config, build_fn, build_fn)?;
 
-        taos.exec("DROP DATABASE IF EXISTS training_data")?;
-        taos.exec("DROP DATABASE IF EXISTS task")?;
+//         taos.exec("DROP DATABASE IF EXISTS training_data")?;
+//         taos.exec("DROP DATABASE IF EXISTS task")?;
 
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+// }

--- a/cml-tdengine/src/lib.rs
+++ b/cml-tdengine/src/lib.rs
@@ -8,8 +8,6 @@
 use anyhow::Result;
 use taos::taos_query::Manager;
 use taos::{sync::*, Pool};
-#[macro_use]
-extern crate derive_builder;
 
 mod core;
 mod models;

--- a/cml-tdengine/src/models/databases.rs
+++ b/cml-tdengine/src/models/databases.rs
@@ -3,11 +3,11 @@ pub(crate) mod options;
 use anyhow::Result;
 use cml_core::handler::Handler;
 use taos::*;
+use typed_builder::TypedBuilder;
 
 use options::{CacheModel, ReplicaNum, SingleSTable};
 
-#[derive(Builder)]
-#[builder(pattern = "owned")]
+#[derive(TypedBuilder)]
 pub(crate) struct Database<'a> {
     name: &'a str,
     duration: i16,


### PR DESCRIPTION
@lazyky 义父，please assist me in completing this PR. The tasks that need to be done are as follows:

- Replace all instances of `derive-builder` with `typed-builder`
- Rewrite the unit test for the `Inference` trait to cover the scenario of two threads simultaneously operating on the same batch (you can refer to the `Register` trait for guidance)
- Use `tempfile::NamedTempFile` for temporary files
- Replace the type of `working_status`, which is a property of `TaskConfig`, with `&[&str]`, which is the same as the signature of `Inference::inference`.