### PR TITLE
feat: Delete optional_tags and transfer only tag_name

### DIFF
--- a/cml-core/src/core/inference.rs
+++ b/cml-core/src/core/inference.rs
@@ -19,8 +19,8 @@ pub trait Inference<M, F, T, C: Manager> {
     fn init_inference(
         &self,
         target_type: M,
+        tag_name: &str,
         optional_fields: Option<Vec<M>>,
-        optional_tags: Option<Vec<M>>,
     ) -> impl Future<Output = Result<()>> + Send;
 
     fn inference<FN>(

--- a/cml-core/src/core/register.rs
+++ b/cml-core/src/core/register.rs
@@ -16,8 +16,8 @@ pub trait Register<M, F, C: Manager> {
     fn init_register(
         &self,
         gt_type: M,
+        tag_name: &str,
         optional_fields: Option<Vec<M>>,
-        optional_tags: Option<Vec<M>>,
     ) -> impl Future<Output = Result<()>> + Send;
 
     fn register(

--- a/cml-core/src/core/task.rs
+++ b/cml-core/src/core/task.rs
@@ -15,8 +15,8 @@ pub struct TaskConfig<'a> {
 pub trait Task<M> {
     fn init_task(
         &self,
+        tag_name: &str,
         optional_fields: Option<Vec<M>>,
-        optional_tags: Option<Vec<M>>,
     ) -> impl Future<Output = Result<()>> + Send;
 
     fn run<FN>(

--- a/cml-tdengine/src/core/inference.rs
+++ b/cml-tdengine/src/core/inference.rs
@@ -12,19 +12,15 @@ impl<D: IntoDsn + Clone + Sync> Inference<Field, Value, i64, Manager<TaosBuilder
     fn init_inference(
         &self,
         target_type: Field,
+        tag_name: &str,
         optional_fields: Option<Vec<Field>>,
-        optional_tags: Option<Vec<Field>>,
     ) -> impl Future<Output = Result<()>> + Send {
         let mut fields = vec![Field::new("ts", Ty::Timestamp, 8), target_type];
         if let Some(f) = optional_fields {
             fields.extend_from_slice(&f);
         }
 
-        let mut tags = vec![Field::new("model_update_time", Ty::Timestamp, 8)];
-        if let Some(t) = optional_tags {
-            tags.extend_from_slice(&t);
-        }
-
+        let tags = vec![Field::new(tag_name, Ty::Json, 518)];
         let stable = STable::new("inference", fields, tags);
 
         async {
@@ -169,7 +165,7 @@ mod tests {
 
         db.init(&cml.build().await?, None).await?;
 
-        cml.init_inference(Field::new("output", Ty::Float, 8), None, None)
+        cml.init_inference(Field::new("output", Ty::Float, 8), "mmp", None)
             .await?;
 
         assert_eq!(

--- a/cml-tdengine/src/core/register.rs
+++ b/cml-tdengine/src/core/register.rs
@@ -13,8 +13,8 @@ impl<D: IntoDsn + Clone + Sync> Register<Field, Value, Manager<TaosBuilder>> for
     fn init_register(
         &self,
         gt_type: Field,
+        tag_name: &str,
         optional_fields: Option<Vec<Field>>,
-        optional_tags: Option<Vec<Field>>,
     ) -> impl Future<Output = Result<()>> + Send {
         let mut fields = vec![
             Field::new("ts", Ty::Timestamp, 8),
@@ -25,11 +25,7 @@ impl<D: IntoDsn + Clone + Sync> Register<Field, Value, Manager<TaosBuilder>> for
             fields.extend_from_slice(&f);
         }
 
-        let mut tags = vec![Field::new("model_update_time", Ty::Timestamp, 8)];
-        if let Some(t) = optional_tags {
-            tags.extend_from_slice(&t);
-        }
-
+        let tags = vec![Field::new(tag_name, Ty::Timestamp, 518)];
         let stable = STable::new("training_data", fields, tags);
         async {
             let client = self.build().await?;
@@ -156,13 +152,10 @@ mod tests {
 
         cml.init_register(
             Field::new("gt", Ty::Float, 8),
+            "mmp",
             Some(vec![
                 Field::new("fucking_field_1", Ty::VarChar, 8),
                 Field::new("fucking_field_2", Ty::TinyInt, 8),
-            ]),
-            Some(vec![
-                Field::new("fucking_tag_1", Ty::VarChar, 8),
-                Field::new("fucking_tag_2", Ty::TinyInt, 8),
             ]),
         )
         .await?;

--- a/cml-tdengine/src/core/task.rs
+++ b/cml-tdengine/src/core/task.rs
@@ -27,8 +27,8 @@ struct TaskInfo {
 impl<D: IntoDsn + Clone + Sync> Task<Field> for TDengine<D> {
     fn init_task(
         &self,
+        tag_name: &str,
         optional_fields: Option<Vec<Field>>,
-        optional_tags: Option<Vec<Field>>,
     ) -> impl Future<Output = Result<()>> + Send {
         let mut fields = vec![
             Field::new("ts", Ty::Timestamp, 8),
@@ -38,11 +38,7 @@ impl<D: IntoDsn + Clone + Sync> Task<Field> for TDengine<D> {
             fields.extend_from_slice(&f);
         }
 
-        let mut tags = vec![Field::new("model_update_time", Ty::Timestamp, 8)];
-        if let Some(t) = optional_tags {
-            tags.extend_from_slice(&t);
-        }
-
+        let tags = vec![Field::new(tag_name, Ty::Timestamp, 518)];
         let stable = STable::new("task", fields, tags);
         async {
             let client = self.build().await?;
@@ -176,7 +172,7 @@ mod tests {
             .build();
         db.init(&cml.build().await?, None).await?;
 
-        cml.init_task(None, None).await?;
+        cml.init_task("mmp", None).await?;
 
         assert_eq!(
             taos_query::AsyncFetchable::to_records(


### PR DESCRIPTION
- JSON type can only be used for one tag in [TDengine](https://docs.tdengine.com/taos-sql/json/). 
